### PR TITLE
Add optional motor current modification before/after filament changes

### DIFF
--- a/hw_configurations/PRUSAMMU.hwcfg
+++ b/hw_configurations/PRUSAMMU.hwcfg
@@ -6,6 +6,14 @@
 ## use_id: should M104 commands have tool id. M104 S210 or M104 S210 T1. Firmware dependent
 tool.temperature.use_id:  False
 
+## Extruder motor current values. Adjusts motor current using M907. Values are 
+## for load/unload and for normal operation.
+## load = motor current for load/unload
+## run = motor current for normal operation
+## These can be set to 0 if not applicable
+motor.current.load: 750
+motor.current.run: 550
+
 ## Prepurge means the fast purge movements that purge old material
 ## before tool change
 ## length = length of one sweep

--- a/hw_configurations/Prometheus-PEEK-PRO-12.hwcfg
+++ b/hw_configurations/Prometheus-PEEK-PRO-12.hwcfg
@@ -4,6 +4,14 @@
 ## use_id: should M104 commands have tool id. M104 S210 or M104 S210 T1. Firmware dependent
 tool.temperature.use_id:  True
 
+## Extruder motor current values. Adjusts motor current using M907. Values are 
+## for load/unload and for normal operation.
+## load = motor current for load/unload
+## run = motor current for normal operation
+## These can be set to 0 if not applicable
+motor.current.load: 0
+motor.current.run: 0
+
 ## Prepurge means the fast purge movements that purge old material
 ## before tool change
 ## length = length of one sweep

--- a/hw_configurations/Prometheus-PEEK-PRO-24.hwcfg
+++ b/hw_configurations/Prometheus-PEEK-PRO-24.hwcfg
@@ -4,6 +4,14 @@
 ## use_id: should M104 commands have tool id. M104 S210 or M104 S210 T1. Firmware dependent
 tool.temperature.use_id:  True
 
+## Extruder motor current values. Adjusts motor current using M907. Values are 
+## for load/unload and for normal operation.
+## load = motor current for load/unload
+## run = motor current for normal operation
+## These can be set to 0 if not applicable
+motor.current.load: 0
+motor.current.run: 0
+
 ## Prepurge means the fast purge movements that purge old material
 ## before tool change
 ## length = length of one sweep

--- a/hw_configurations/Prometheus-PEEK-PRO-24_PrePrime.hwcfg
+++ b/hw_configurations/Prometheus-PEEK-PRO-24_PrePrime.hwcfg
@@ -4,6 +4,22 @@
 ## use_id: should M104 commands have tool id. M104 S210 or M104 S210 T1. Firmware dependent
 tool.temperature.use_id:  True
 
+## Extruder motor current values. Adjusts motor current using M907. Values are 
+## for load/unload and for normal operation.
+## load = motor current for load/unload
+## run = motor current for normal operation
+## These can be set to 0 if not applicable
+motor.current.load: 0
+motor.current.run: 0
+
+## Extruder motor current values. Adjusts motor current using M907. Values are 
+## for load/unload and for normal operation.
+## load = motor current for load/unload
+## run = motor current for normal operation
+## These can be set to 0 if not applicable
+motor.current.load: 750
+motor.current.run: 550
+
 ## Prepurge means the fast purge movements that purge old material
 ## before tool change
 ## length = length of one sweep

--- a/hw_configurations/Prometheus-PTFE-EV6.hwcfg
+++ b/hw_configurations/Prometheus-PTFE-EV6.hwcfg
@@ -4,6 +4,14 @@
 ## use_id: should M104 commands have tool id. M104 S210 or M104 S210 T1. Firmware dependent
 tool.temperature.use_id:  True
 
+## Extruder motor current values. Adjusts motor current using M907. Values are 
+## for load/unload and for normal operation.
+## load = motor current for load/unload
+## run = motor current for normal operation
+## These can be set to 0 if not applicable
+motor.current.load: 0
+motor.current.run: 0
+
 ## Prepurge means the fast purge movements that purge old material
 ## before tool change
 ## length = length of one sweep

--- a/hw_configurations/Prometheus-PTFE-EV6_PrePrime.hwcfg
+++ b/hw_configurations/Prometheus-PTFE-EV6_PrePrime.hwcfg
@@ -4,6 +4,14 @@
 ## use_id: should M104 commands have tool id. M104 S210 or M104 S210 T1. Firmware dependent
 tool.temperature.use_id:  True
 
+## Extruder motor current values. Adjusts motor current using M907. Values are 
+## for load/unload and for normal operation.
+## load = motor current for load/unload
+## run = motor current for normal operation
+## These can be set to 0 if not applicable
+motor.current.load: 0
+motor.current.run: 0
+
 ## Prepurge means the fast purge movements that purge old material
 ## before tool change
 ## length = length of one sweep

--- a/hw_configurations/Prometheus-PTFE-PRO-12.hwcfg
+++ b/hw_configurations/Prometheus-PTFE-PRO-12.hwcfg
@@ -4,6 +4,14 @@
 ## use_id: should M104 commands have tool id. M104 S210 or M104 S210 T1. Firmware dependent
 tool.temperature.use_id:  True
 
+## Extruder motor current values. Adjusts motor current using M907. Values are 
+## for load/unload and for normal operation.
+## load = motor current for load/unload
+## run = motor current for normal operation
+## These can be set to 0 if not applicable
+motor.current.load: 0
+motor.current.run: 0
+
 ## Prepurge means the fast purge movements that purge old material
 ## before tool change
 ## length = length of one sweep

--- a/hw_configurations/Prometheus-PTFE-PRO-24.hwcfg
+++ b/hw_configurations/Prometheus-PTFE-PRO-24.hwcfg
@@ -4,6 +4,14 @@
 ## use_id: should M104 commands have tool id. M104 S210 or M104 S210 T1. Firmware dependent
 tool.temperature.use_id:  True
 
+## Extruder motor current values. Adjusts motor current using M907. Values are 
+## for load/unload and for normal operation.
+## load = motor current for load/unload
+## run = motor current for normal operation
+## These can be set to 0 if not applicable
+motor.current.load: 0
+motor.current.run: 0
+
 ## Prepurge means the fast purge movements that purge old material
 ## before tool change
 ## length = length of one sweep

--- a/hw_configurations/Prometheus-PTFE-PRO-24_PrePrime.hwcfg
+++ b/hw_configurations/Prometheus-PTFE-PRO-24_PrePrime.hwcfg
@@ -4,6 +4,14 @@
 ## use_id: should M104 commands have tool id. M104 S210 or M104 S210 T1. Firmware dependent
 tool.temperature.use_id:  True
 
+## Extruder motor current values. Adjusts motor current using M907. Values are 
+## for load/unload and for normal operation.
+## load = motor current for load/unload
+## run = motor current for normal operation
+## These can be set to 0 if not applicable
+motor.current.load: 0
+motor.current.run: 0
+
 ## Prepurge means the fast purge movements that purge old material
 ## before tool change
 ## length = length of one sweep

--- a/src/gcode.py
+++ b/src/gcode.py
@@ -351,6 +351,15 @@ class GCode:
         :return: byte string
         """
         return ("T%d" % tool).encode()
+        
+    def gen_motor_current(self, axis, current):
+    	"""
+    	Send M907 to adjust motor current
+    	:param axis: the axis to adjust (usually E)
+    	:param current: motor current
+    	:return: byte string
+    	"""
+    	return ("M907 %s%d" % (axis, current)).encode()
 
     def gen_absolute_positioning(self):
         """


### PR DESCRIPTION
Prusa changes extruder motor current during filament changes using M907. This adds optional M907 using hwconfig parameters motor.current.load and motor.current.run.